### PR TITLE
Migrate to Are.na API v3 and support local HTTPS

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,6 @@
 PORT=3000
 SECRET=
+CLIENT_ID=
+CLIENT_SECRET=
+CALLBACK_URL=https://localhost:3000/auth/arena/callback
+CLIPPINGS_CHANNEL_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+certs/
+
 # Logs
 logs
 *.log

--- a/lib/brain.js
+++ b/lib/brain.js
@@ -6,9 +6,8 @@ const config = require('../config')
 const axios = require('axios')
 const Kindle = require('./kindle')
 
-let FormData = require('form-data')
-
 const CHANNELS_PER_PAGE = 50
+const API_BASE = 'https://api.are.na/v3'
 
 module.exports = class Brain {
   constructor (accessToken) {
@@ -16,26 +15,26 @@ module.exports = class Brain {
     this.user = undefined
   }
 
+  authHeaders () {
+    return { Authorization: `Bearer ${this.accessToken}` }
+  }
+
   getMe (request, response) {
-    return new Promise((resolve, reject) => {
-      axios.get(`https://api.are.na/v2/me?access_token=${this.accessToken}`).then((response) => {
-        this.user = response.data
-        resolve(this.user)
-      })
+    return axios.get(`${API_BASE}/me`, { headers: this.authHeaders() }).then((response) => {
+      this.user = response.data
+      return this.user
     })
   }
 
   createBlock (channelID, { title, description, content }) {
-    let url = `https://api.are.na/v2/channels/${channelID}/blocks?access_token=${this.accessToken}`
+    let body = {
+      value: content,
+      title,
+      description,
+      channel_ids: [channelID]
+    }
 
-    let data = new FormData()
-    data.append('content', content)
-    data.append('title', title)
-    data.append('description', description)
-
-    let config = { method: 'post', url, headers: { ...data.getHeaders() }, data }
-
-    return axios(config) 
+    return axios.post(`${API_BASE}/blocks`, body, { headers: this.authHeaders() })
       .then(response => {
         return response.data
       }).catch((error) => {
@@ -45,11 +44,10 @@ module.exports = class Brain {
   }
 
   publishSnippet (request, response) {
-
     let channelID = request.body.channel
-    let content = request.body.content 
-    let title = request.body.title 
-    let description = request.body.description 
+    let content = request.body.content
+    let title = request.body.title
+    let description = request.body.description
 
     let user = request.session.passport && request.session.passport.user
 
@@ -58,24 +56,12 @@ module.exports = class Brain {
       return
     }
 
-    if (request.body.share) {
-      this.addCollaborator(user).then(() => {
-      
-        this.createBlock(process.env.CLIPPINGS_CHANNEL_ID, { title, description, content }).then((data) => {
-
-          this.createBlock(channelID, { title, description, content }).then((data) => {
-            response.json({ success: 'ok' })
-          })
-        })
-      })
-    } else {
-      this.createBlock(channelID, { title, description, content }).then((data) => {
-        response.json({ success: 'ok' })
-      }).catch((error) => {
-        console.error(error)
-        response.json([])
-      })
-    }
+    this.createBlock(channelID, { title, description, content }).then((data) => {
+      response.json({ success: 'ok' })
+    }).catch((error) => {
+      console.error(error)
+      response.json([])
+    })
   }
 
   getClippings (request, response) {
@@ -95,7 +81,7 @@ module.exports = class Brain {
       }
 
       let match = book.title.match(/(.*?)\((.*)\)$/)
-      let title 
+      let title
       let source = undefined
 
       if (!match) {
@@ -113,7 +99,7 @@ module.exports = class Brain {
       clippings[title].clippings.push(book)
     })
 
-    Object.keys(clippings).forEach((key) => { 
+    Object.keys(clippings).forEach((key) => {
       let book = clippings[key]
       let count = book.clippings.filter(clipping => clipping.limited).length
       clippings[key].limited = count
@@ -128,37 +114,22 @@ module.exports = class Brain {
   }
 
   getUserChannels (user, page, data = []) {
-    let url = `https://api.are.na/v2/users/${user.id}/channels`
-    let params =  { params: { access_token: this.accessToken, per: CHANNELS_PER_PAGE, page }}
+    let url = `${API_BASE}/users/${user.id}/contents`
+    let params = {
+      params: { per: CHANNELS_PER_PAGE, page, type: 'Channel' },
+      headers: this.authHeaders()
+    }
 
-    return axios.get(url, params) 
+    return axios.get(url, params)
       .then(response => {
-        let channels = response.data.channels
+        let channels = response.data.data
+        data.push(...channels)
 
-        if (page <= response.data.total_pages) {
-          data.push(...channels)
-
+        if (response.data.meta.has_more_pages) {
           return this.getUserChannels(user, page + 1, data)
         } else {
           return data
         }
-      }).catch((error) => {
-        console.error(error)
-        return []
-      })
-  }
-
-  addCollaborator (user) {
-    let url = `https://api.are.na/v2/channels/${process.env.CLIPPINGS_CHANNEL_ID}/collaborators?access_token=${process.env.ACCESS_TOKEN}`
-
-    let data = new FormData()
-    data.append('ids[]', user.id)
-
-    let config = { method: 'post', url, headers: { ...data.getHeaders() }, data }
-
-    return axios(config) 
-      .then(response => {
-        return response.data
       }).catch((error) => {
         console.error(error)
         return []
@@ -175,10 +146,10 @@ module.exports = class Brain {
 
     this.getUserChannels(user, 1).then((data) => {
 
-      let channels = data.map((channel) => { 
-        return { slug: channel.slug, title: channel.title, status: channel.status }
-      }).filter((channel) => { 
-        return channel.slug !== process.env.CLIPPINGS_CHANNEL_ID 
+      let channels = data.map((channel) => {
+        return { slug: channel.slug, title: channel.title, visibility: channel.visibility }
+      }).filter((channel) => {
+        return channel.slug !== process.env.CLIPPINGS_CHANNEL_ID
       })
 
       response.json(channels)

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,9 @@
         "webpack-dev-middleware": "^3.7.2",
         "webpack-dev-server": "^3.11.0",
         "webpack-hot-middleware": "^2.25.0"
+      },
+      "engines": {
+        "node": "18.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "start:client": "webpack-dev-server --config webpack.config.js",
-    "start": "babel-watch ./server.js"
+    "start": "babel-watch ./server.js",
+    "cert": "mkdir -p certs && openssl req -x509 -newkey rsa:2048 -keyout certs/key.pem -out certs/cert.pem -days 365 -nodes -subj '/CN=localhost' -addext 'subjectAltName=DNS:localhost,IP:127.0.0.1'"
   },
   "author": {
     "name": "Javier Arce",

--- a/server.js
+++ b/server.js
@@ -1,5 +1,7 @@
 require('dotenv').config()
 
+const fs = require('fs')
+const https = require('https')
 const path = require('path')
 const express = require('express')
 const app = express()
@@ -80,8 +82,8 @@ passport.deserializeUser((user, done) => {
 
 if (process.env.CLIENT_ID && process.env.CLIENT_SECRET) {
   passport.use(new OAuth2Strategy({
-    authorizationURL: 'https://dev.are.na/oauth/authorize',
-    tokenURL: 'https://dev.are.na/oauth/token',
+    authorizationURL: 'https://www.are.na/oauth/authorize',
+    tokenURL: 'https://api.are.na/v3/oauth/token',
     clientID: process.env.CLIENT_ID,
     clientSecret: process.env.CLIENT_SECRET,
     callbackURL: process.env.CALLBACK_URL
@@ -110,12 +112,24 @@ app.get('/api/status', (request, response) => { Brain && Brain.getStatus(request
 app.post('/api/clippings', (request, response) => { Brain.getClippings(request, response) })
 app.post('/api/publish', (request, response) => { Brain.publishSnippet(request, response)})
 app.get('/api/channels', (request, response) => { Brain.getChannels(request, response)})
-app.get('/api/collaborate', (request, response) => { Brain.addCollaborator(request, response)})
 
 app.get('/', function(request, response) {
   response.sendFile(__dirname + '/public/index.html')
 })
 
-const listener = app.listen(process.env.PORT, function() {
-  console.log('Your app is listening on port ' + listener.address().port)
-})
+const port = process.env.PORT
+const keyFile = path.join(__dirname, 'certs', 'key.pem')
+const certFile = path.join(__dirname, 'certs', 'cert.pem')
+
+if (fs.existsSync(keyFile) && fs.existsSync(certFile)) {
+  https.createServer({
+    key: fs.readFileSync(keyFile),
+    cert: fs.readFileSync(certFile)
+  }, app).listen(port, () => {
+    console.log(`Your app is listening on https://localhost:${port}`)
+  })
+} else {
+  app.listen(port, () => {
+    console.log(`Your app is listening on http://localhost:${port}`)
+  })
+}

--- a/src/components/Channels.vue
+++ b/src/components/Channels.vue
@@ -82,7 +82,7 @@ export default {
       this.selectedChannelID = +e.target.dataset.index
       let channel = this.data[this.selectedChannelID]
       this.selectedChannel = this.truncate(channel.title, 20)
-      this.selectedChannelStatus = channel.status
+      this.selectedChannelStatus = channel.visibility
       this.selectedChannelURL = `https://are.na/${window.bus.user.slug}/${channel.slug}`
 
       this.showChannels = false 
@@ -99,7 +99,7 @@ export default {
     channelClass (index) {
       let classes = []
 
-      classes.push(`is-${this.data[index].status}` )
+      classes.push(`is-${this.data[index].visibility}` )
 
       if (this.selectedChannelID === index) {
         classes.push('is-selected' )

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -42,7 +42,7 @@ export default {
         this.name = 'Log in **'
         this.URL = '/auth/arena'
       } else {
-        this.name = user.username
+        this.name = user.name
         this.URL = `https://are.na/${user.slug}`
         this.isLoggedIn = true
       }

--- a/src/main.js
+++ b/src/main.js
@@ -32,7 +32,7 @@ window.bus = new Vue({
       window.bus.$emit(config.ACTIONS.SHOW_MESSAGE, message)
     },
     isLoggedIn () {
-      return !!(this.user && this.user.username)
+      return !!(this.user && this.user.slug)
     },
     getTitle () {
       return config.ADMIN.TITLE


### PR DESCRIPTION
## Summary
- Migrates all API calls and OAuth endpoints to Are.na v3: bearer-token auth, `POST /v3/blocks` (with `value`/`channel_ids`), `GET /v3/users/:id/contents?type=Channel`, and the new pagination shape (`meta.has_more_pages`).
- Removes the share-to-clippings-channel flow and the `/api/collaborate` route since v3 has no collaborator endpoint.
- Updates the client to read the v3 user shape (`name`/`slug` instead of `username`) and renames channel `status` → `visibility`.
- Adds opt-in HTTPS for local dev: drop a cert into `./certs/` (or run `npm run cert`) and the server boots over HTTPS.

## Test plan
- [ ] Log in via OAuth and confirm the corner button shows your display name and the in-book "Log in" button disappears.
- [ ] Send highlights to a channel and verify the block is created.
- [ ] Confirm the channel list loads with correct visibility styling (public/private/closed).
- [ ] `npm run cert` then restart and confirm the server boots on `https://localhost:3000`.