### PR TITLE
Fix gradient tiling and last-row spacing on long pages

### DIFF
--- a/src/assets/scss/style.scss
+++ b/src/assets/scss/style.scss
@@ -41,10 +41,8 @@ body {
   padding: 0;
   background: #ffd951;
   transition: background 250ms ease-in-out;
-  background: linear-gradient(125deg, #ffd951 0%, #51ffaf 20%);
-  background-repeat: repeat;
-  background-position: 0 0;
-  background-size: 400% 400%;
+  background: linear-gradient(125deg, #ffd951 0%, #51ffaf 100%) fixed;
+  background-repeat: no-repeat;
 }
 
 a {
@@ -108,7 +106,7 @@ body.is-dragover .Books__infoInner {
   display: flex;
   flex-direction: column;
   align-items: center;
-  height: 100%;
+  min-height: 100%;
 }
 
 .Backdrop {


### PR DESCRIPTION
## Summary
- Body gradient used `background-size: 400% 400%` with `repeat`, producing visible yellow→green→yellow seams on tall pages. Replaced with a viewport-fixed gradient over the full color range so it stays smooth at any page length.
- `.Home` was `height: 100%`, so when the books grid overflowed the viewport the `8em` bottom margin on `.Books` got clipped. Changed to `min-height: 100%` so the last row gets proper breathing room.

## Test plan
- [ ] Load a library with many books and confirm no banding in the background as you scroll.
- [ ] Confirm the last row of books has space below it instead of touching the window edge.