### PR TITLE
Center drop zone vertically on the home screen

### DIFF
--- a/src/assets/scss/Books.scss
+++ b/src/assets/scss/Books.scss
@@ -111,7 +111,7 @@
 }
 
 .Books__info {
-  height: 100%;
+  flex: 1;
   max-width: 80%;
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## Summary
- Replace `height: 100%` with `flex: 1` on `.Books__info` so the drop zone fills the available vertical space inside the flex-column `.Home` (which only sets `min-height: 100%`), keeping its inner pill centered instead of collapsing to content height and overlapping the fixed title.

## Test plan
- [ ] Open the app with no books loaded and confirm the "Drag & drop your Kindle's clippings in here" pill is centered vertically and does not overlap the title.